### PR TITLE
Fix(#996): Updating the 'bearer' string according to the One Platform standard.

### DIFF
--- a/video-library-service/service.ts
+++ b/video-library-service/service.ts
@@ -50,12 +50,14 @@ const apollo = new ApolloServer({
   subscriptions: {
     path: '/subscriptions',
   },
-  formatError: error => ({
-    message: error.message,
-    locations: error.locations,
-    stack: error.stack ? error.stack.split('\n') : [],
-    path: error.path,
-  }),
+  formatError: error => {
+    console.error(error);
+    return {
+      message: error.message,
+      locations: error.locations,
+      stack: error.stack ? error.stack.split('\n') : [],
+      path: error.path,
+  }},
   extensions
 });
 

--- a/video-library-service/src/helpers.ts
+++ b/video-library-service/src/helpers.ts
@@ -81,7 +81,7 @@ class VideoLibraryHelpers {
     fetchUserDetails(query: String){
       const headers = {
         'Content-Type': 'application/json',
-        Authorization: `bearer: ${process.env.API_KEY}`,
+        Authorization: `Bearer ${process.env.API_KEY}`,
       };
       const agent = new https.Agent({
         rejectUnauthorized: false,

--- a/video-library-service/src/mailmanCron.ts
+++ b/video-library-service/src/mailmanCron.ts
@@ -77,7 +77,7 @@ export class MailmanCron {
                       }`;
                       const headers = {
                         'Content-Type': 'application/json',
-                        Authorization: `bearer: ${process.env.API_KEY}`,
+                        Authorization: `Bearer ${process.env.API_KEY}`,
                       };
                       const agent = new https.Agent({
                         rejectUnauthorized: false,


### PR DESCRIPTION
# Fixes - ONEPLAT-996

# Explain the feature/fix

Updating the 'bearer' string according to the One Platform standard. Recent changes in the One Platform API gateway were breaking listVideos query in GraphQL.
 

## Does this PR introduce a breaking change
No